### PR TITLE
Ruby 1.8.7 Syntax Compatibility

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use ruby-1.9.2-p290@handlebars_assets

--- a/lib/handlebars_assets/engine.rb
+++ b/lib/handlebars_assets/engine.rb
@@ -1,6 +1,6 @@
 module HandlebarsAssets
   class Engine < ::Rails::Engine
-    initializer "sprockets.handlebars", after: "sprockets.environment" do |app|
+    initializer "sprockets.handlebars", :after => "sprockets.environment" do |app|
       next unless app.assets
       app.assets.register_engine('.hbs', TiltHandlebars)
     end


### PR DESCRIPTION
I found that I only needed to switch the syntax of a single line for it to work in an app of mine requiring Ruby 1.8.7.

I'm not sure if removing the .rvmrc file was necessary for the pull request, but thought I'd throw it in there anyway...

Wonderful gem, by the way.
