### PR TITLE
Change suggested in #6 to make this work with Rails 3.1.1.rc2

### DIFF
--- a/lib/handlebars_assets/engine.rb
+++ b/lib/handlebars_assets/engine.rb
@@ -1,6 +1,6 @@
 module HandlebarsAssets
   class Engine < ::Rails::Engine
-    initializer "sprockets.handlebars", :after => "sprockets.environment" do |app|
+    initializer "sprockets.handlebars", :after => "sprockets.environment", :group => :assets do |app|
       next unless app.assets
       app.assets.register_engine('.hbs', TiltHandlebars)
     end


### PR DESCRIPTION
Makes the engine work with Rails 3.1.1.rc2's way of asset pre compilation
