### PR TITLE
Add options to attr_writer

### DIFF
--- a/lib/handlebars_assets/config.rb
+++ b/lib/handlebars_assets/config.rb
@@ -5,7 +5,7 @@ module HandlebarsAssets
   module Config
     extend self
 
-    attr_writer :compiler, :compiler_path, :known_helpers, :known_helpers_only, :path_prefix, :template_namespace
+    attr_writer :compiler, :compiler_path, :known_helpers, :known_helpers_only, :options, :path_prefix, :template_namespace
 
     def compiler
       @compiler || 'handlebars.js'


### PR DESCRIPTION
the options method is set up to take passed in options, but the attr_writer doesn't have it.  Looks unintended.

In my case I want to do:

```
HandlebarsAssets::Config.options = { data: true }
```
