### PR TITLE
Add support for .handlebars extension

### DIFF
--- a/lib/handlebars_assets.rb
+++ b/lib/handlebars_assets.rb
@@ -16,5 +16,6 @@ module HandlebarsAssets
   else
     require 'sprockets'
     Sprockets.register_engine '.hbs', TiltHandlebars
+    Sprockets.register_engine '.handlebars', TiltHandlebars
   end
 end

--- a/lib/handlebars_assets/engine.rb
+++ b/lib/handlebars_assets/engine.rb
@@ -3,6 +3,7 @@ module HandlebarsAssets
     initializer "sprockets.handlebars", :after => "sprockets.environment", :group => :all do |app|
       next unless app.assets
       app.assets.register_engine('.hbs', TiltHandlebars)
+      app.assets.register_engine('.handlebars', TiltHandlebars)
     end
   end
 end


### PR DESCRIPTION
The ember-rails gem had a similar pull request because many (including the creator of Handlebars) prefer the .handlebars extension over hjs and hbs.
