### PR TITLE
Fix partial names for Ember

### DIFF
--- a/lib/handlebars_assets/tilt_handlebars.rb
+++ b/lib/handlebars_assets/tilt_handlebars.rb
@@ -94,7 +94,11 @@ module HandlebarsAssets
       end
 
       def partial_name
-        forced_underscore_name.gsub(/\//, '_').gsub(/__/, '_').dump
+        if HandlebarsAssets::Config.ember?
+          relative_path.dump
+        else
+          forced_underscore_name.gsub(/\//, '_').gsub(/__/, '_').dump
+        end
       end
 
       def template_name

--- a/test/handlebars_assets/tilt_handlebars_test.rb
+++ b/test/handlebars_assets/tilt_handlebars_test.rb
@@ -140,5 +140,17 @@ module HandlebarsAssets
       expected_compiled = %{window.Ember.TEMPLATES["test_render"] = Ember.Handlebars.compile("This is {{handlebars}}");};
       assert_equal expected_compiled, template.render(scope, {})
     end
+
+    def test_ember_partials
+      root = '/myapp/app/assets/templates'
+      file = 'test/_partial.hbs'
+      scope = make_scope root, file
+      source = "This is {{handlebars}}"
+
+      HandlebarsAssets::Config.ember = true
+      template = HandlebarsAssets::TiltHandlebars.new(scope.pathname.to_s) { source }
+      expected_compiled = %{window.Ember.TEMPLATES["test/_partial"] = Ember.Handlebars.compile("This is {{handlebars}}");};
+      assert_equal expected_compiled, template.render(scope, {})
+    end
   end
 end


### PR DESCRIPTION
Ember requires partial names like `post/_user`. 

Without this patch, putting `_user.hbs` inside the `post` directory results in the `_post_user` template name.
