### PR TITLE
Synchronize Sprockets engine registers with Rails

### DIFF
--- a/lib/handlebars_assets.rb
+++ b/lib/handlebars_assets.rb
@@ -17,5 +17,7 @@ module HandlebarsAssets
     require 'sprockets'
     Sprockets.register_engine '.hbs', TiltHandlebars
     Sprockets.register_engine '.handlebars', TiltHandlebars
+    Sprockets.register_engine('.hamlbars', TiltHandlebars) if HandlebarsAssets::Config.haml_available?
+    Sprockets.register_engine('.slimbars', TiltHandlebars) if HandlebarsAssets::Config.slim_available?
   end
 end


### PR DESCRIPTION
It might be worth considering DRYing up handlebars.rb and
handlebars_assets/engine.rb.
