### PR TITLE
Resister engine using `Sprockets` vs `app.assets`.

### DIFF
--- a/lib/handlebars_assets/engine.rb
+++ b/lib/handlebars_assets/engine.rb
@@ -2,10 +2,10 @@ module HandlebarsAssets
   class Engine < ::Rails::Engine
     initializer "sprockets.handlebars", :after => "sprockets.environment", :group => :all do |app|
       next unless app.assets
-      app.assets.register_engine('.hbs', TiltHandlebars)
-      app.assets.register_engine('.handlebars', TiltHandlebars)
-      app.assets.register_engine('.hamlbars', TiltHandlebars) if HandlebarsAssets::Config.haml_available?
-      app.assets.register_engine('.slimbars', TiltHandlebars) if HandlebarsAssets::Config.slim_available?
+      Sprockets.register_engine('.hbs', TiltHandlebars)
+      Sprockets.register_engine('.handlebars', TiltHandlebars)
+      Sprockets.register_engine('.hamlbars', TiltHandlebars) if HandlebarsAssets::Config.haml_available?
+      Sprockets.register_engine('.slimbars', TiltHandlebars) if HandlebarsAssets::Config.slim_available?
     end
   end
 end


### PR DESCRIPTION
In rare cases with other eninges mounted, using `app.assets` sprockets engine instance causes a `can't modify immutable index` errors like this one below when compiling assets.

```
** Execute assets:environment
** Invoke environment (first_time)
** Execute environment
rake aborted!
can't modify immutable index
/Users/kencollins/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/sprockets-2.2.2/lib/sprockets/index.rb:80:in `expire_index!'
/Users/kencollins/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/sprockets-2.2.2/lib/sprockets/processing.rb:32:in `register_engine'
/Users/kencollins/.rbenv/versions/1.9.3-p392lib/ruby/gems/1.9.1/gems/handlebars_assets-0.12.1/lib/handlebars_assets/engine.rb:5:in `block in <class:Engine>'
```

I have found that using `register_engine` with `Sprockets` solves the issue. Even tho I have authored a few gems like `less-rails`, I am uncertain why this is the case and how the issues really manifested. I can say that it appears that using `Sprockets.register_engine` vs `app.assets.register_engine` is the preferred way, see searches below.

https://github.com/search?q=Sprockets.register_engine&ref=cmdform&type=Code
https://github.com/search?q=app.assets.register_engine&ref=cmdform&type=Code

If required, I would be more than willing to investigate why this may be the best way to register a template engine. For now, I only made it as far as reading the [`Sprockets::Index`](https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/index.rb) comments and where the specific [exception was raised](https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/index.rb#L80).  
