### PR TITLE
Register template handlers very early on. Fixes #70.

### DIFF
--- a/lib/handlebars_assets.rb
+++ b/lib/handlebars_assets.rb
@@ -1,3 +1,4 @@
+require 'sprockets'
 require "handlebars_assets/version"
 
 module HandlebarsAssets
@@ -14,7 +15,6 @@ module HandlebarsAssets
   if defined?(Rails) && defined?(::Rails::Engine)
     require 'handlebars_assets/engine'
   else
-    require 'sprockets'
     Sprockets.register_engine '.hbs', TiltHandlebars
     Sprockets.register_engine '.handlebars', TiltHandlebars
     Sprockets.register_engine('.hamlbars', TiltHandlebars) if HandlebarsAssets::Config.haml_available?

--- a/lib/handlebars_assets/engine.rb
+++ b/lib/handlebars_assets/engine.rb
@@ -1,7 +1,6 @@
 module HandlebarsAssets
   class Engine < ::Rails::Engine
-    initializer "sprockets.handlebars", :after => "sprockets.environment", :group => :all do |app|
-      next unless app.assets
+    config.before_initialize do |app|
       Sprockets.register_engine('.hbs', TiltHandlebars)
       Sprockets.register_engine('.handlebars', TiltHandlebars)
       Sprockets.register_engine('.hamlbars', TiltHandlebars) if HandlebarsAssets::Config.haml_available?


### PR DESCRIPTION
This does not have the app.assets guard. It would not work anyway since config.assets is not yet populated at this time nor. Besides, the only thing this was doing was not calling methods on Sprockets which is going to be there one way or another or fail much earlier on in your require's before engine.rb is required.
