### PR TITLE
fixes regex matching template names

### DIFF
--- a/lib/handlebars_assets/tilt_handlebars.rb
+++ b/lib/handlebars_assets/tilt_handlebars.rb
@@ -106,7 +106,7 @@ module HandlebarsAssets
       end
 
       def is_ember?
-        full_path.to_s =~ %r{.ember(.hbs|.hamlbars|.slimbars)?$}
+        full_path.to_s =~ %r{\.ember(\.hbs|\.hamlbars|\.slimbars)?$}
       end
 
       def name

--- a/test/handlebars_assets/tilt_handlebars_test.rb
+++ b/test/handlebars_assets/tilt_handlebars_test.rb
@@ -152,6 +152,7 @@ module HandlebarsAssets
     def test_multiple_frameworks_with_ember_render
       root = '/myapp/app/assets/templates'
       non_ember = 'test_render.hbs'
+      non_ember_but_with_ember = 'test_member.hbs'
       ember_ext_no_hbs = 'test_render.ember'
       ember_ext = 'test_render.ember.hbs'
       ember_with_haml = 'test_render.ember.hamlbars'
@@ -165,6 +166,12 @@ module HandlebarsAssets
       source = "This is {{handlebars}}"
       template = HandlebarsAssets::TiltHandlebars.new(scope.pathname.to_s) { source }
       assert_equal hbs_compiled('test_render', source), template.render(scope, {})
+
+      # File without ember extension but with ember in it should compile to default namespace
+      scope = make_scope root, non_ember_but_with_ember
+      source = "This is {{handlebars}}"
+      template = HandlebarsAssets::TiltHandlebars.new(scope.pathname.to_s) { source }
+      assert_equal hbs_compiled('test_member', source), template.render(scope, {})
 
       # File with ember extension should compile to ember specific namespace
       expected_compiled = %{window.Ember.TEMPLATES["test_render"] = Ember.Handlebars.compile("This is {{handlebars}}");};


### PR DESCRIPTION
The regex for matching against the template path was matching against `<any character>ember` instead of `.ember`, hence if you had a template called `member.hbs` it would be treated as an ember template.
