### PR TITLE
Erb templates

### DIFF
--- a/lib/handlebars_assets/tilt_handlebars.rb
+++ b/lib/handlebars_assets/tilt_handlebars.rb
@@ -106,7 +106,7 @@ module HandlebarsAssets
       end
 
       def is_ember?
-        full_path.to_s =~ %r{\.ember(\.hbs|\.hamlbars|\.slimbars)?$}
+        full_path.to_s =~ %r{\.ember(\.hbs|\.hamlbars|\.slimbars)?}
       end
 
       def name

--- a/test/handlebars_assets/tilt_handlebars_test.rb
+++ b/test/handlebars_assets/tilt_handlebars_test.rb
@@ -157,6 +157,7 @@ module HandlebarsAssets
       ember_ext = 'test_render.ember.hbs'
       ember_with_haml = 'test_render.ember.hamlbars'
       ember_with_slim = 'test_render.ember.slimbars'
+      ember_ext_with_erb = 'test_render.ember.hbs.erb'
 
       HandlebarsAssets::Config.ember = true
       HandlebarsAssets::Config.multiple_frameworks = true
@@ -176,6 +177,12 @@ module HandlebarsAssets
       # File with ember extension should compile to ember specific namespace
       expected_compiled = %{window.Ember.TEMPLATES["test_render"] = Ember.Handlebars.compile("This is {{handlebars}}");};
       scope = make_scope root, ember_ext_no_hbs
+      template = HandlebarsAssets::TiltHandlebars.new(scope.pathname.to_s) { source }
+      assert_equal expected_compiled, template.render(scope, {})
+
+      # File with ember and erb extension should compile to ember specific namespace
+      expected_compiled = %{window.Ember.TEMPLATES["test_render"] = Ember.Handlebars.compile("This is {{handlebars}}");};
+      scope = make_scope root, ember_ext_with_erb
       template = HandlebarsAssets::TiltHandlebars.new(scope.pathname.to_s) { source }
       assert_equal expected_compiled, template.render(scope, {})
 


### PR DESCRIPTION
Adds handling `.hbs.erb` (or other extensions) files so you can for example use `<%= image_path %>` in the template.

I've forked this off of the branch for #101 so that should be merged first.
