### PR TITLE
Allows assets to precompile properly in Ruby 1.8

### DIFF
--- a/lib/handlebars_assets/engine.rb
+++ b/lib/handlebars_assets/engine.rb
@@ -1,7 +1,7 @@
 module HandlebarsAssets
   # NOTE: must be an engine because we are including assets in the gem
   class Engine < ::Rails::Engine
-    initializer "handlebars_assets.assets.register", group: :all do |app|
+    initializer "handlebars_assets.assets.register", :group => :all do |app|
       ::HandlebarsAssets::register_extensions(app.assets)
     end
   end


### PR DESCRIPTION
This is the only place where Ruby 2 syntax is being used and causes errors when running assets:precompile on a Ruby 1.8 machine. 
