### PR TITLE
Add chomp underscore flag for partials

### DIFF
--- a/lib/handlebars_assets/config.rb
+++ b/lib/handlebars_assets/config.rb
@@ -11,7 +11,8 @@ module HandlebarsAssets
       :patch_files, :patch_path, :path_prefix, :slim_options, :template_namespace,
       :precompile, :haml_enabled, :slim_enabled,
       :handlebars_extensions, :hamlbars_extensions, :slimbars_extensions,
-      :amd, :handlebars_amd_path, :amd_with_template_namespace
+      :amd, :handlebars_amd_path, :amd_with_template_namespace,
+      :chomp_underscore_for_partials
 
     def compiler
       @compiler || 'handlebars.js'
@@ -123,6 +124,14 @@ module HandlebarsAssets
     # during configuration for the handlebars
     def handlebars_amd_path
       @handlebars_amd_path || 'handlebars'
+    end
+
+    # Indicate if leading underscore should be allowed
+    # when creating partial definition.
+    # Allows compatibility with handlebars-rails
+    # https://github.com/cowboyd/handlebars-rails/blob/f73a2d11df8aa2c21d335b8f04a8c5b59ae6a790/lib/handlebars-rails/tilt.rb#L18
+    def chomp_underscore_for_partials?
+      @chomp_underscore_for_partials || false
     end
 
     private

--- a/lib/handlebars_assets/handlebars_template.rb
+++ b/lib/handlebars_assets/handlebars_template.rb
@@ -190,7 +190,11 @@ module HandlebarsAssets
       private
 
       def relative_path
-        @full_path.match(/.*#{HandlebarsAssets::Config.path_prefix}\/((.*\/)*([^.]*)).*$/)[1]
+        path = @full_path.match(/.*#{HandlebarsAssets::Config.path_prefix}\/((.*\/)*([^.]*)).*$/)[1]
+        if is_partial? && ::HandlebarsAssets::Config.chomp_underscore_for_partials?
+          path.gsub!(%r~/_~, '/')
+        end
+        path
       end
 
       def template_name

--- a/lib/handlebars_assets/handlebars_template.rb
+++ b/lib/handlebars_assets/handlebars_template.rb
@@ -192,6 +192,9 @@ module HandlebarsAssets
       def relative_path
         path = @full_path.match(/.*#{HandlebarsAssets::Config.path_prefix}\/((.*\/)*([^.]*)).*$/)[1]
         if is_partial? && ::HandlebarsAssets::Config.chomp_underscore_for_partials?
+          #handle case if partial is in root level of template folder
+          path.gsub!(%r~^_~, '')
+          #handle case if partial is in a subfolder within the template folder
           path.gsub!(%r~/_~, '/')
         end
         path

--- a/test/handlebars_assets/tilt_handlebars_test.rb
+++ b/test/handlebars_assets/tilt_handlebars_test.rb
@@ -74,6 +74,31 @@ module HandlebarsAssets
       assert_equal hbs_compiled_partial('some/thing/_test_underscore', source), template2.render(scope2, {})
     end
 
+    def test_chomped_underscore_partials
+      assert_equal HandlebarsAssets::Config.chomp_underscore_for_partials?, false
+
+      HandlebarsAssets::Config.chomp_underscore_for_partials = true
+      assert_equal HandlebarsAssets::Config.chomp_underscore_for_partials?, true
+
+      root = '/myapp/app/assets/javascripts'
+      file1 = 'app/templates/_test_underscore.hbs'
+      scope1 = make_scope root, file1
+      file2 = 'app/templates/some/thing/_test_underscore.hbs'
+      scope2 = make_scope root, file2
+      source = "This is {{handlebars}}"
+
+      HandlebarsAssets::Config.path_prefix = 'app/templates'
+
+      template1 = HandlebarsAssets::HandlebarsTemplate.new(scope1.pathname.to_s) { source }
+
+      assert_equal hbs_compiled_partial('test_underscore', source), template1.render(scope1, {})
+
+      template2 = HandlebarsAssets::HandlebarsTemplate.new(scope2.pathname.to_s) { source }
+
+      assert_equal hbs_compiled_partial('some/thing/test_underscore', source), template2.render(scope2, {})
+
+    end
+
     def test_without_known_helpers_opt
       root = '/myapp/app/assets/templates'
       file = 'test_without_known.hbs'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,6 +55,7 @@ module HandlebarsAssets
     extend self
 
     def reset!
+      @chomp_underscore_for_partials = nil
       @compiler = nil
       @compiler_path = nil
       @haml_options = nil


### PR DESCRIPTION
I have a couple of rails apps, some that use client side handlebars via handlebars_assets and some that use server side handlebars via handlebars-rails.

Unfortunately, using shared handlebar files between my apps do not work because of the way handlebars_assets and handlebars-rails each handle naming partials. 

Both detect a partial by checking for a leading underscore. But handlebars-rails strips the underscore from the name when registering the partial. (see: https://github.com/cowboyd/handlebars-rails/blob/f73a2d11df8aa2c21d335b8f04a8c5b59ae6a790/lib/handlebars-rails/tilt.rb#L18).

This PR adds a config option (disabled by default) to strip the underscore from partials, so the partial register behavior is the same between both gems.