### PR TITLE
reset config and handlebars on tests setup instead of teardown

### DIFF
--- a/test/handlebars_assets/compiling_test.rb
+++ b/test/handlebars_assets/compiling_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module HandlebarsAssets
   class CompilingTest < ::MiniTest::Test
 
-    def teardown
+    def setup
       HandlebarsAssets::Config.reset!
       HandlebarsAssets::Handlebars.reset!
     end

--- a/test/handlebars_assets/hamlbars_test.rb
+++ b/test/handlebars_assets/hamlbars_test.rb
@@ -5,13 +5,13 @@ module HandlebarsAssets
     include SprocketsScope
     include CompilerSupport
 
-    def compile_haml(source)
-      (Haml::Engine.new(source, HandlebarsAssets::Config.haml_options).render).chomp
-    end
-
-    def teardown
+    def setup
       HandlebarsAssets::Config.reset!
       HandlebarsAssets::Handlebars.reset!
+    end
+
+    def compile_haml(source)
+      (Haml::Engine.new(source, HandlebarsAssets::Config.haml_options).render).chomp
     end
 
     def test_render_haml

--- a/test/handlebars_assets/slimbars_test.rb
+++ b/test/handlebars_assets/slimbars_test.rb
@@ -5,13 +5,13 @@ module HandlebarsAssets
     include SprocketsScope
     include CompilerSupport
 
-    def compile_slim(source)
-      Slim::Template.new(HandlebarsAssets::Config.slim_options) { source }.render
-    end
-
-    def teardown
+    def setup
       HandlebarsAssets::Config.reset!
       HandlebarsAssets::Handlebars.reset!
+    end
+
+    def compile_slim(source)
+      Slim::Template.new(HandlebarsAssets::Config.slim_options) { source }.render
     end
 
     def test_render_slim

--- a/test/handlebars_assets/tilt_handlebars_test.rb
+++ b/test/handlebars_assets/tilt_handlebars_test.rb
@@ -7,7 +7,7 @@ module HandlebarsAssets
     include CompilerSupport
     include SprocketsScope
 
-    def teardown
+    def setup
       HandlebarsAssets::Config.reset!
       HandlebarsAssets::Handlebars.reset!
     end


### PR DESCRIPTION
This allows overriding defaults in test/test_helper.rb
