### PR TITLE
Remove asset version modifier based on handlebars version

### DIFF
--- a/lib/handlebars_assets/engine.rb
+++ b/lib/handlebars_assets/engine.rb
@@ -3,7 +3,6 @@ module HandlebarsAssets
   class Engine < ::Rails::Engine
     initializer "handlebars_assets.assets.register", :group => :all do |app|
       ::HandlebarsAssets::register_extensions(app.assets)
-      app.assets.version += "#{::HandlebarsAssets::VERSION}"
     end
   end
 end

--- a/lib/handlebars_assets/version.rb
+++ b/lib/handlebars_assets/version.rb
@@ -1,3 +1,3 @@
 module HandlebarsAssets
-  VERSION = "0.22.0"
+  VERSION = "0.22.1"
 end


### PR DESCRIPTION
Fixes #143.

As discussed in the issue, by appending the `HandlebarsAssets::VERSION` to the global assets version identifier, this triggers a complete change to _all_ assets whenever the HandlebarsAssets version number changes, even though only the handlebars runtime (and potentially some handlebars templates) will have changed. Also, since Sprockets is smart enough to realise that the version of Handlebars included in a given JS file will result in a different fingerprint, there is no need for this to be handled in the gem anyway.
