### PR TITLE
Fixes a bug that was preventing Rails app startup

### DIFF
--- a/lib/handlebars_assets/engine.rb
+++ b/lib/handlebars_assets/engine.rb
@@ -2,7 +2,7 @@ module HandlebarsAssets
   # NOTE: must be an engine because we are including assets in the gem
   class Engine < ::Rails::Engine
     initializer "handlebars_assets.assets.register", :group => :all do |app|
-      config.assets.configure do |sprockets_env|
+      app.config.assets.configure do |sprockets_env|
         ::HandlebarsAssets::register_extensions(sprockets_env)
         if Gem::Version.new(Sprockets::VERSION) < Gem::Version.new('3')
           ::HandlebarsAssets::add_to_asset_versioning(sprockets_env)


### PR DESCRIPTION
Error was:

```
'method_missing': undefined method `assets' for #<Rails::Engine::Configuration:0x007fca48b60e58> (NoMethodError)
from handlebars_assets/lib/handlebars_assets/engine.rb:5:in 'block in <class:Engine>'
```

Seems to be a simple logic error here:

```ruby
class Engine < ::Rails::Engine
    initializer "handlebars_assets.assets.register", :group => :all do |app|
      config.assets.configure do |sprockets_env|
      # ...
    end
end
```

Note that `config` does not exist here, however `app.config` does. Changing to that fixes the problem.

Surprised no one else has encountered this as it completely prevented my Rails app from starting.
