### PR TITLE
[WIP] Pass context to renderer

### DIFF
--- a/lib/handlebars_assets/handlebars_template.rb
+++ b/lib/handlebars_assets/handlebars_template.rb
@@ -62,7 +62,8 @@ module HandlebarsAssets
     def call(input)
       renderer = HandlebarsRenderer.new(path: input[:filename])
       engine = renderer.choose_engine(input[:data])
-      renderer.compile(engine.render)
+      context = input[:environment].context_class.new(input)
+      renderer.compile(engine.render(context))
     end
   end
 

--- a/test/handlebars_assets/handlebars_processor_test.rb
+++ b/test/handlebars_assets/handlebars_processor_test.rb
@@ -11,7 +11,14 @@ module HandlebarsAssets
     end
 
     def render_it(scope, source)
-      HandlebarsAssets::HandlebarsProcessor.call(filename: scope.pathname.to_s, data: source)
+      environment = Sprockets::Environment.new
+      input = {
+        environment: environment,
+        filename: scope.pathname.to_s,
+        data: source,
+        metadata: {}
+      }
+      HandlebarsAssets::HandlebarsProcessor.call(input)
     end
   end
 end


### PR DESCRIPTION
This PR is based on a fix from https://github.com/leshill/handlebars_assets/issues/150

It adds passing context to renderer, so we can call `image_path`, `asset_path`, and other helpers again.