### PR TITLE
Fix sprockets version check

### DIFF
--- a/lib/handlebars_assets.rb
+++ b/lib/handlebars_assets.rb
@@ -17,7 +17,7 @@ module HandlebarsAssets
   end
 
   def self.register_extensions(sprockets_environment)
-    if Gem::Version.new(Sprockets::VERSION) < Gem::Version.new('3')
+    if Gem::Version.new(Sprockets::VERSION) < Gem::Version.new('4')
       Config.handlebars_extensions.each do |ext|
         sprockets_environment.register_engine(ext, HandlebarsTemplate)
       end


### PR DESCRIPTION
Based on [this](https://github.com/leshill/handlebars_assets/blob/master/lib/handlebars_assets/handlebars_template.rb#L15), we want `HandlebarsTemplate` to be used for rendering if Sprockets version is 3 or lower.

But in [this file](https://github.com/leshill/handlebars_assets/blob/master/lib/handlebars_assets.rb#L20), we check if Sprockets version is less than 3, so all Sprockets versions higher than 3.0 will be affected, which causes a bug when asset helpers are not available.

[Reduced test case](https://github.com/Borzik/handlebars_assets_rtc) is updated, you can test it now if you want (check Gemfile for versions).
