### PR TITLE
Remove dependency on json, multi_json

### DIFF
--- a/handlebars_assets.gemspec
+++ b/handlebars_assets.gemspec
@@ -21,14 +21,12 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "execjs", "~> 2.0"
   s.add_runtime_dependency "tilt", ">= 1.2"
-  s.add_runtime_dependency "multi_json", "~> 1.0"
   s.add_runtime_dependency "sprockets", ">= 2.0.0"
 
   s.add_development_dependency "minitest", '~> 5.5'
   s.add_development_dependency "haml", '~> 4.0'
   s.add_development_dependency "rake", '~> 10.0'
   s.add_development_dependency "slim", '~> 3.0'
-  s.add_development_dependency "json", '~> 1.7'
   s.add_development_dependency "appraisal"
 
   s.post_install_message = "Remember to rake assets:clean or rake assets:purge on update! this is required because of handlebars updates"


### PR DESCRIPTION
JSON is built in to ruby since 1.9, and multi_json isn't used.

This follows [other gems](https://github.com/rails/rails/pull/23453) dropping the dependency on json.