### PR TITLE
Add a before_initialize block for older versions of Rails

### DIFF
--- a/lib/handlebars_assets/engine.rb
+++ b/lib/handlebars_assets/engine.rb
@@ -1,12 +1,18 @@
 module HandlebarsAssets
   # NOTE: must be an engine because we are including assets in the gem
   class Engine < ::Rails::Engine
-    initializer "handlebars_assets.assets.register", :group => :all do |app|
-      app.config.assets.configure do |sprockets_env|
-        ::HandlebarsAssets::register_extensions(sprockets_env)
-        if Gem::Version.new(Sprockets::VERSION) < Gem::Version.new('3')
-          ::HandlebarsAssets::add_to_asset_versioning(sprockets_env)
+    if Gem::Version.new(Rails.version) >= Gem::Version.new('4')
+      initializer "handlebars_assets.assets.register", :group => :all do |app|
+        app.config.assets.configure do |sprockets_env|
+          ::HandlebarsAssets::register_extensions(sprockets_env)
+          if Gem::Version.new(Sprockets::VERSION) < Gem::Version.new('3')
+            ::HandlebarsAssets::add_to_asset_versioning(sprockets_env)
+          end
         end
+      end
+    else
+      config.before_initialize do
+        ::HandlebarsAssets::register_extensions(Sprockets)
       end
     end
   end


### PR DESCRIPTION
this allows the gem to leverage Sprockets which is necessary to pick up the 'hbs' file extension.