### PR TITLE
Updating handlebars.js and handlebars.runtime.js to version 4.7.7

### DIFF
--- a/vendor/assets/javascripts/handlebars.js
+++ b/vendor/assets/javascripts/handlebars.js
@@ -1,7 +1,7 @@
 /**!
 
  @license
- handlebars v4.7.3
+ handlebars v4.7.7
 
 Copyright (C) 2011-2019 by Yehuda Katz
 
@@ -278,7 +278,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _internalProtoAccess = __webpack_require__(33);
 
-	var VERSION = '4.7.3';
+	var VERSION = '4.7.7';
 	exports.VERSION = VERSION;
 	var COMPILER_REVISION = 8;
 	exports.COMPILER_REVISION = COMPILER_REVISION;
@@ -1525,7 +1525,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          loc: loc
 	        });
 	      }
-	      return obj[name];
+	      return container.lookupProperty(obj, name);
 	    },
 	    lookupProperty: function lookupProperty(parent, propertyName) {
 	      var result = parent[propertyName];
@@ -3903,7 +3903,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return this.internalNameLookup(parent, name);
 	  },
 	  depthedLookup: function depthedLookup(name) {
-	    return [this.aliasable('container.lookup'), '(depths, "', name, '")'];
+	    return [this.aliasable('container.lookup'), '(depths, ', JSON.stringify(name), ')'];
 	  },
 
 	  compilerInfo: function compilerInfo() {

--- a/vendor/assets/javascripts/handlebars.runtime.js
+++ b/vendor/assets/javascripts/handlebars.runtime.js
@@ -1,7 +1,7 @@
 /**!
 
  @license
- handlebars v4.7.3
+ handlebars v4.7.7
 
 Copyright (C) 2011-2019 by Yehuda Katz
 
@@ -209,7 +209,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _internalProtoAccess = __webpack_require__(32);
 
-	var VERSION = '4.7.3';
+	var VERSION = '4.7.7';
 	exports.VERSION = VERSION;
 	var COMPILER_REVISION = 8;
 	exports.COMPILER_REVISION = COMPILER_REVISION;
@@ -1456,7 +1456,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          loc: loc
 	        });
 	      }
-	      return obj[name];
+	      return container.lookupProperty(obj, name);
 	    },
 	    lookupProperty: function lookupProperty(parent, propertyName) {
 	      var result = parent[propertyName];


### PR DESCRIPTION
Updating handlebars.js to address security issues. [This issue](https://github.com/handlebars-lang/handlebars.js/issues/1736) in the handlebars repo addresses possible RCE documented [here](https://snyk.io/vuln/SNYK-JS-HANDLEBARS-1056767)