### PR TITLE
Support for Haml 6.x

### DIFF
--- a/handlebars_assets.gemspec
+++ b/handlebars_assets.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "sprockets", ">= 2.0.0"
 
   s.add_development_dependency "minitest", '~> 5.5'
-  s.add_development_dependency "haml", '~> 4.0'
-  s.add_development_dependency "rake", '~> 10.0'
+  s.add_development_dependency "haml", ">= 4.0"
+  s.add_development_dependency "rake", '>= 10.0'
   s.add_development_dependency "slim", '~> 3.0'
   s.add_development_dependency "appraisal"
 

--- a/handlebars_assets.gemspec
+++ b/handlebars_assets.gemspec
@@ -23,10 +23,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "tilt", ">= 1.2"
   s.add_runtime_dependency "sprockets", ">= 2.0.0"
 
-  s.add_development_dependency "minitest", '~> 5.5'
-  s.add_development_dependency "haml", ">= 4.0"
-  s.add_development_dependency "rake", '>= 10.0'
-  s.add_development_dependency "slim", '~> 3.0'
+  s.add_development_dependency "minitest", "~> 5.5"
+  s.add_development_dependency "haml", ">= 4.0", "< 7.0"
+  s.add_development_dependency "rake", ">= 10.0", "< 14.0"
+  s.add_development_dependency "slim", "~> 3.0"
   s.add_development_dependency "appraisal"
 
   s.post_install_message = "Remember to rake assets:clean or rake assets:purge on update! this is required because of handlebars updates"

--- a/lib/handlebars_assets/handlebars_template.rb
+++ b/lib/handlebars_assets/handlebars_template.rb
@@ -103,7 +103,11 @@ module HandlebarsAssets
 
     def choose_engine(data)
       if @template_path.is_haml?
-        Haml::Engine.new(data, HandlebarsAssets::Config.haml_options)
+        if Haml::VERSION >= "6.0.0"
+          Haml::Template.new(HandlebarsAssets::Config.haml_options) { data }
+        else
+          Haml::Engine.new(data, HandlebarsAssets::Config.haml_options)
+        end
       elsif @template_path.is_slim?
         Slim::Template.new(HandlebarsAssets::Config.slim_options) { data }
       else

--- a/test/handlebars_assets/compiling_test.rb
+++ b/test/handlebars_assets/compiling_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
+require 'minitest'
 
 module HandlebarsAssets
-  class CompilingTest < ::MiniTest::Test
+  class CompilingTest < Minitest::Test
 
     def teardown
       HandlebarsAssets::Config.reset!
@@ -14,7 +15,7 @@ module HandlebarsAssets
       HandlebarsAssets::Config.compiler_path = File.expand_path '../../edge', __FILE__
 
       compiled = Handlebars.precompile(source, HandlebarsAssets::Config.options)
-      assert_match /PRECOMPILE CALLED/, compiled
+      assert_match(/PRECOMPILE CALLED/, compiled)
     end
 
     def test_patching_handlebars
@@ -24,7 +25,7 @@ module HandlebarsAssets
       HandlebarsAssets::Config.patch_files = ['patch.js']
 
       compiled = Handlebars.precompile(source, HandlebarsAssets::Config.options)
-      assert_match /CALLED PATCH/, compiled
+      assert_match(/CALLED PATCH/, compiled)
     end
   end
 end

--- a/test/handlebars_assets/hamlbars_test.rb
+++ b/test/handlebars_assets/hamlbars_test.rb
@@ -6,7 +6,11 @@ module HandlebarsAssets
     include CompilerSupport
 
     def compile_haml(source)
-      (Haml::Engine.new(source, HandlebarsAssets::Config.haml_options).render).chomp
+      if Haml::VERSION >= "6.0.0"
+        ((Haml::Template.new(HandlebarsAssets::Config.haml_options) { source }).render).chomp
+      else
+        (Haml::Engine.new(source, HandlebarsAssets::Config.haml_options).render).chomp        
+      end
     end
 
     def teardown


### PR DESCRIPTION
Added support for Haml 6.x. It really boils down to the 6.x change

```
Haml::Engine.new(str, options)
# ->
Haml::Template.new(options) { str }
```