### PR TITLE
fix the reference error in js strict mode

### DIFF
--- a/lib/handlebars_assets/handlebars_template.rb
+++ b/lib/handlebars_assets/handlebars_template.rb
@@ -170,9 +170,9 @@ module HandlebarsAssets
           else
             unindent <<-TEMPLATE
               define(['#{handlebars_amd_path}'],function(Handlebars){
-                this.#{template_namespace} || (this.#{template_namespace} = {});
-                this.#{template_namespace}[#{@template_path.name}] = #{template};
-                return this.#{template_namespace}[#{@template_path.name}];
+                window.#{template_namespace} || (window.#{template_namespace} = {});
+                window.#{template_namespace}[#{@template_path.name}] = #{template};
+                return window.#{template_namespace}[#{@template_path.name}];
               });
             TEMPLATE
           end
@@ -187,10 +187,10 @@ module HandlebarsAssets
         else
           unindent <<-TEMPLATE
             (function() {
-              this.#{template_namespace} || (this.#{template_namespace} = {});
-              this.#{template_namespace}[#{@template_path.name}] = #{template};
-              return this.#{template_namespace}[#{@template_path.name}];
-            }).call(this);
+              window.#{template_namespace} || (window.#{template_namespace} = {});
+              window.#{template_namespace}[#{@template_path.name}] = #{template};
+              return window.#{template_namespace}[#{@template_path.name}];
+            }).call(window);
           TEMPLATE
         end
       end

--- a/vendor/assets/javascripts/handlebars.js
+++ b/vendor/assets/javascripts/handlebars.js
@@ -33,7 +33,7 @@ THE SOFTWARE.
 		exports["Handlebars"] = factory();
 	else
 		root["Handlebars"] = factory();
-})(this, function() {
+})(this || window, function() {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};

--- a/vendor/assets/javascripts/handlebars.runtime.js
+++ b/vendor/assets/javascripts/handlebars.runtime.js
@@ -33,7 +33,7 @@ THE SOFTWARE.
 		exports["Handlebars"] = factory();
 	else
 		root["Handlebars"] = factory();
-})(this, function() {
+})(this || window, function() {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};


### PR DESCRIPTION
Rails 7 (Sprockets v4 ) has an `Undefined` error while requiring it in application.js, because it is trying to refer it in strict mode.